### PR TITLE
Update GitHub Actions checkout to fetch two commits

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2 # To check for changes in the last commit
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
<!---
1-2 sentences summarizing the changes included in this PR
--->

Update GitHub Actions publish workflow to fetch commit history with depth of 2 to enable checking changes in the last commit.

## Changes
<!---
List all non-trivial changes included in this PR. Bullet points are fine or the individual commits that make up this PR.
--->

- Added `fetch-depth: 2` configuration to the `actions/checkout@v4` step in the GitHub Actions publish workflow
- Added comment explaining the purpose: "To check for changes in the last commit"

## Testing
<!---
How did you test your changes? How might someone else test them?
--->

N/A

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.